### PR TITLE
[ADD] open_academy: Creation of Courses Menu T#59081

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
 # mqt pre-commit lint check files
 .eslintrc.json
 .flake8
@@ -5,3 +8,6 @@
 .pre-commit-config.yaml
 .pylintrc
 .pylintrc-optional
+
+# vscode configuration
+.vscode

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "name": "open_academy",
+    "name": "Open Academy",
 
     "summary": "Creation of the open academy module.",
 
@@ -17,6 +17,7 @@
 
     "data": [
         "security/ir.model.access.csv",
+        "views/course_menu.xml",
     ],
 
     "demo": [

--- a/open_academy/views/course_menu.xml
+++ b/open_academy/views/course_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="course_action" model="ir.actions.act_window">
+        <field name="name">Courses</field>
+        <field name="res_model">course</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="course_menu" name="Courses" sequence="10" action="course_action"/>
+</odoo>


### PR DESCRIPTION
Add menu entries to access courses of the open_academy module
Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#actions-and-menus

Add __pycache__ and .vscode configuration to gitignore

Fix name of the module in manifest that was changed due to a mistake in the last commit