### PR TITLE
[ADD] open_academy: Add inherited partner model T#59081

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -19,6 +19,7 @@
         "security/ir.model.access.csv",
         "views/course_views.xml",
         "views/session_views.xml",
+        "views/res_partner_views.xml",
     ],
 
     "demo": [

--- a/open_academy/models/__init__.py
+++ b/open_academy/models/__init__.py
@@ -1,2 +1,3 @@
 from . import course
 from . import session
+from . import res_partner

--- a/open_academy/models/res_partner.py
+++ b/open_academy/models/res_partner.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    is_instructor = fields.Boolean()
+    session_ids = fields.Many2many("session")

--- a/open_academy/views/res_partner_views.xml
+++ b/open_academy/views/res_partner_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.view.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group/group[1]/field[@name='vat']" position="after">
+                <field name="is_instructor" />
+            </xpath>
+            <xpath expr="//sheet/notebook/page[@name='internal_notes']" position="after">
+                <page name="session_ids" string="Sessions">
+                    <field name="session_ids" />
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add instructor and session_ids fields to partner model through inheritance.
- Add inherited partner view to show if the partner is instructor and the sessions they will attend.

![Captura](https://user-images.githubusercontent.com/108701886/182494230-766e9641-46fe-4365-8248-46e244c055e2.png)

Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#view-inheritance