### PR TITLE
[IMP] open_academy: Add instructor and teacher domain T#59081

### DIFF
--- a/open_academy/models/res_partner.py
+++ b/open_academy/models/res_partner.py
@@ -6,3 +6,7 @@ class Partner(models.Model):
 
     is_instructor = fields.Boolean()
     session_ids = fields.Many2many("session")
+    teacher_level = fields.Selection([
+        ("1", "Level 1"),
+        ("2", "Level 2"),
+    ])

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -9,6 +9,11 @@ class Session(models.Model):
     start_date = fields.Date()
     duration = fields.Float()
     number_of_seats = fields.Integer()
-    instructor_id = fields.Many2one("res.partner")
+    instructor_id = fields.Many2one(
+        "res.partner",
+        domain=['|',
+                ('is_instructor', '=', True),
+                ('teacher_level', '!=', False)],
+    )
     course_id = fields.Many2one("course", required=True)
     attendee_ids = fields.Many2many("res.partner", string="Attendees")

--- a/open_academy/views/res_partner_views.xml
+++ b/open_academy/views/res_partner_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet/group/group[1]/field[@name='vat']" position="after">
                 <field name="is_instructor" />
+                <field name="teacher_level" />
             </xpath>
             <xpath expr="//sheet/notebook/page[@name='internal_notes']" position="after">
                 <page name="session_ids" string="Sessions">


### PR DESCRIPTION
- Add teacher_level field in res_partner model to add a selection of teacher level to the partner view.
- Add domain to instructor_id field at session model to display only partners that are instructors or teachers in session form view.

Teacher level select in Partner form view:
![image](https://user-images.githubusercontent.com/108701886/182693074-482e5e40-6bdc-42ed-9a5d-1a2c792cceb9.png)

Session form view with only instructors and teachers in the select, where item 1 and item 2 are instructors, item 3 is level 1 teacher and item 4 is level 2 teacher:
![Captura desde 2022-08-03 13-52-55](https://user-images.githubusercontent.com/108701886/182692001-e6bcf70a-6c35-45ff-9f94-9077dab83425.png)

Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#domains