### PR TITLE
[IMP] open_academy: Add taken_seats computed field T#59081

### DIFF
--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class Session(models.Model):
@@ -6,7 +6,8 @@ class Session(models.Model):
     _description = 'Open Academy Session'
 
     name = fields.Char(required=True)
-    start_date = fields.Date()
+    active = fields.Boolean(default=True)
+    start_date = fields.Date(default=lambda self: fields.Date.today())
     duration = fields.Float()
     number_of_seats = fields.Integer()
     instructor_id = fields.Many2one(
@@ -17,3 +18,12 @@ class Session(models.Model):
     )
     course_id = fields.Many2one("course", required=True)
     attendee_ids = fields.Many2many("res.partner", string="Attendees")
+    taken_seats = fields.Integer(compute="_compute_taken_seats", store=True)
+
+    @api.depends("number_of_seats", "attendee_ids")
+    def _compute_taken_seats(self):
+        for record in self:
+            taken_seats = 0
+            if record.number_of_seats > 0:
+                taken_seats = len(record.attendee_ids) * 100 / record.number_of_seats
+            record.taken_seats = taken_seats

--- a/open_academy/views/session_views.xml
+++ b/open_academy/views/session_views.xml
@@ -17,8 +17,10 @@
                 <field name="course_id"/>
                 <field name="instructor_id"/>
                 <field name="start_date"/>
-                <field name="number_of_seats"/>
                 <field name="duration"/>
+                <field name="number_of_seats"/>
+                <field name="taken_seats" widget="progressbar"/>
+                <field name="active"/>
             </tree>
         </field>
     </record>
@@ -28,17 +30,19 @@
         <field name="model">session</field>
         <field name="arch" type="xml">
             <form>
-                <group colspan="4" col="4">
-                    <field name="name"/>
-                    <field name="course_id"/>
-                </group>
-                <group colspan="4" col="4">
-                    <field name="instructor_id"/>
-                    <field name="start_date"/>
-                </group>
-                <group colspan="4" col="4">
-                    <field name="number_of_seats"/>
-                    <field name="duration"/>
+                <group>
+                    <group>
+                        <field name="name"/>
+                        <field name="instructor_id"/>
+                        <field name="number_of_seats"/>
+                        <field name="taken_seats" widget="progressbar"/>
+                    </group>
+                    <group>
+                        <field name="course_id"/>
+                        <field name="start_date"/>
+                        <field name="duration"/>
+                        <field name="active"/>
+                    </group>
                 </group>
                 <notebook colspan="4">
                     <page string="Attendees">


### PR DESCRIPTION
- Add taken_seats field to the session model and views to show the computed percentage of taken seats as a progress bar.
- Add a dependency to taken_seats with number_of_seats and attendee_ids to recompute its value on change.
- Change groups in session form view to use only two groups to all fields instead of a group for each two fields.

From exercise "Default values":
- Add today as default value to start_date field in session model.
- Add active field with True as default value to the session model, Tree and Form views.

Taken_seats and active status in Session Tree View: 
![session tree view](https://user-images.githubusercontent.com/108701886/182949939-bb5bcc56-da5d-4303-ad94-ad4839f7f9a7.png)

Default values in start_date and active status in the Session Form View:
![new session](https://user-images.githubusercontent.com/108701886/182950349-0d3738dd-53e4-40b4-861f-6fc565b59d09.png)

Computed value of taken_seats: 
![sesssion form view](https://user-images.githubusercontent.com/108701886/182950902-c17bb2d9-30ba-4da9-9aae-e845a9f46c14.png)


Link to exercises: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#computed-fields-and-default-values