### PR TITLE
[ADD] open_academy: Warning on invalid values T#59081

### DIFF
--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,4 @@
-from odoo import models, fields, api
+from odoo import _, api, fields, models
 
 
 class Session(models.Model):
@@ -27,3 +27,20 @@ class Session(models.Model):
             if record.number_of_seats > 0:
                 taken_seats = len(record.attendee_ids) * 100 / record.number_of_seats
             record.taken_seats = taken_seats
+
+    @api.onchange("number_of_seats", "attendee_ids")
+    def onchange_seats(self):
+        if self.number_of_seats < 0:
+            return {
+                "warning": {
+                    "title": _("Warning"),
+                    "message": _("Number of seats cannot be negative")
+                }
+            }
+        if self.number_of_seats < len(self.attendee_ids):
+            return {
+                "warning": {
+                    "title": _("Warning"),
+                    "message": _("Number of attendees exceeds the number of seats")
+                }
+            }


### PR DESCRIPTION
- Add Onchange method to validate that the number of seats is not negative and that the number of attendees does not exceed the number of seats. 
If validations fail, a warning is returned.

Negative value in number_of_seats field:
![negative value](https://user-images.githubusercontent.com/108701886/183219516-37f81d30-9853-4644-8896-dc17f4f92e6a.png)

Number of Attendees exceed Number of Seats:
![attendees](https://user-images.githubusercontent.com/108701886/183219548-40d2e076-7813-4361-9b24-de4852a05949.png)

Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#onchange
