### PR TITLE
[ADD] open_academy: Add advanced views T#59081

### DIFF
--- a/open_academy/views/course_views.xml
+++ b/open_academy/views/course_views.xml
@@ -4,6 +4,7 @@
         <field name="name">Courses</field>
         <field name="res_model">course</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_my_courses': 1}</field>
     </record>
 
     <menuitem id="course_menu" name="Courses" sequence="10" action="course_action"/>
@@ -34,7 +35,7 @@
                         <field name="description" nolabel="1" />
                     </page>
                     <page string="Sessions">
-                        <field name="session_ids"  nolabel="1"/>
+                        <field name="session_ids" nolabel="1"/>
                     </page>
                 </notebook>
             </form>
@@ -48,6 +49,10 @@
             <search>
                 <field name="name"/>
                 <field name="description"/>
+                <filter name="my_courses" string="My Courses" domain="[('responsible_user_id', '=', uid)]"/>
+                <group string="Group By">
+                    <filter name="group_by_responsible_user" string="Responsible User" context="{'group_by': 'responsible_user_id'}"/>
+                </group>
             </search>
         </field>
     </record>

--- a/open_academy/views/session_views.xml
+++ b/open_academy/views/session_views.xml
@@ -3,7 +3,7 @@
     <record id="session_action" model="ir.actions.act_window">
         <field name="name">Sessions</field>
         <field name="res_model">session</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">tree,form,calendar,graph,kanban</field>
     </record>
 
     <menuitem id="session_menu" name="Sessions" sequence="20" action="session_action"/>
@@ -12,15 +12,17 @@
         <field name="name">session.view.tree</field>
         <field name="model">session</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree decoration-info="5>lasting_days" decoration-danger="lasting_days>15">
                 <field name="name"/>
                 <field name="course_id"/>
                 <field name="instructor_id"/>
                 <field name="start_date"/>
+                <field name="lasting_days"/>
                 <field name="duration"/>
                 <field name="number_of_seats"/>
                 <field name="taken_seats" widget="progressbar"/>
                 <field name="active"/>
+                <field name="attendees_count"/>
             </tree>
         </field>
     </record>
@@ -50,6 +52,70 @@
                     </page>
                 </notebook>
             </form>
+        </field>
+    </record>
+
+    <record id="session_view_calendar" model="ir.ui.view">
+        <field name="name">session.view.calendar</field>
+        <field name="model">session</field>
+        <field name="arch" type="xml">
+            <calendar string="Sessions" date_start="start_date" color="name" date_delay="duration">
+                <field name="name"/>
+                <field name="course_id"/>
+                <field name="instructor_id"/>
+                <field name="start_date"/>
+                <field name="duration"/>
+                <field name="number_of_seats"/>
+                <field name="taken_seats" widget="progressbar"/>
+            </calendar>
+        </field>
+    </record>
+
+    <record id="session_view_graph" model="ir.ui.view">
+        <field name="name">session.view.graph</field>
+        <field name="model">session</field>
+        <field name="arch" type="xml">
+            <graph string="Number of attendees by Course" type="bar">
+                <field name="course_id"/>
+                <field name="attendees_count" type="measure"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="session_view_kanban" model="ir.ui.view">
+        <field name="name">session.view.kanban</field>
+        <field name="model">session</field>
+        <field name="arch" type="xml">
+            <kanban class="o_res_partner_kanban" default_group_by="course_id">
+                <field name="name"/>
+                <field name="instructor_id"/>
+                <field name="start_date"/>
+                <field name="duration"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_global_click">
+                            <div class="oe_kanban_details">
+                                <ul>
+                                    <li>
+                                        <strong>
+                                            <field name="name"/>
+                                        </strong>
+                                    </li>
+                                    <li>
+                                        Instructor: <field name="instructor_id"/>
+                                    </li>
+                                    <li>
+                                        Start Date: <field name="start_date"/>
+                                    </li>
+                                    <li>
+                                        Duration: <field name="duration"/>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Add decoration-info in Session Tree view to color blue sessions lasting less than 5 days.
- Add decoration-danger in Session Tree view to color red sessions lasting more than 15 days.
![tree session](https://user-images.githubusercontent.com/108701886/184408002-68affa09-1c22-4036-a840-753047195462.png)

- Add Calendar view in Session views to display the events in the calendar.
![calendar session](https://user-images.githubusercontent.com/108701886/184262774-aa151e64-3c9d-422a-bcc0-e1893a9f864e.png)

- Add button in search view to filter courses for which the current user is the responsible.
![search default courses](https://user-images.githubusercontent.com/108701886/184262796-6fd7b826-078f-443e-8720-1c6e92b00adb.png)

- Add button in search view to group courses by responsible user.
![group by courses](https://user-images.githubusercontent.com/108701886/184262867-6930dc73-5998-4314-975b-6a77277808c8.png)

- Add Graph view in the Session views to display the number of attendees by course.
![graph session](https://user-images.githubusercontent.com/108701886/184262818-29f37024-de86-45a3-a6dd-2109ae057ba1.png)

- Add Kanban view in Session views to display sessions grouped by course.
![kanban session](https://user-images.githubusercontent.com/108701886/184262853-d6eab435-0df7-4c7e-90ea-2f4b42a303de.png)

Link to exercises: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#advanced-views