### PR TITLE
[ADD] open_academy: Add Manager group and record rule T#59081

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -16,6 +16,8 @@
     ],
 
     "data": [
+        "security/res_groups.xml",
+        "security/ir_rule.xml",
         "security/ir.model.access.csv",
         "views/course_views.xml",
         "views/session_views.xml",

--- a/open_academy/security/ir.model.access.csv
+++ b/open_academy/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_open_academy_course,access_open_academy_course,model_course,base.group_user,1,1,1,1
-access_open_academy_session,access_open_academy_session,model_session,base.group_user,1,1,1,1
+manager_open_academy_session,manager_open_academy_session,model_session,open_academy_group_manager,1,1,1,1
+manager_open_academy_course,manager_open_academy_course,model_course,open_academy_group_manager,1,1,1,1
+read_open_academy_course,read_open_academy_course,model_course,base.group_user,1,0,0,0
+read_open_academy_session,read_open_academy_session,model_session,base.group_user,1,0,0,0

--- a/open_academy/security/ir_rule.xml
+++ b/open_academy/security/ir_rule.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="rule_course_manager" model="ir.rule">
+        <field name="name">Write or Delete responsible own courses</field>
+        <field name="model_id" ref="model_course"/>
+        <field name="groups" eval="[(4, ref('open_academy.open_academy_group_manager'))]"/>
+        <field name="perm_read" eval="0"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="0"/>
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">['|',('responsible_user_id','=','user.id'), ('responsible_user_id','=',False)]</field>
+    </record>
+</odoo>

--- a/open_academy/security/res_groups.xml
+++ b/open_academy/security/res_groups.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="open_academy_group_manager" model="res.groups">
+        <field name="name">OpenAcademy / Manager</field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add Manager group to grant full access to all models to users in this group
![manager group](https://user-images.githubusercontent.com/108701886/184457707-b27a404c-c551-454e-9409-93135868a7fa.png)

- Add only read perms to all users
![read perm](https://user-images.githubusercontent.com/108701886/184457750-4acb387a-49cc-4af8-babe-5c37c8500c18.png)

- Add record rule "course_rule_manager" to restricts write and unlink accesses to the responsible of a course.
![record rule](https://user-images.githubusercontent.com/108701886/184457753-93bfc712-7c4e-4245-8623-0721cbb21ab2.png)

Link to exercises: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#security