### PR TITLE
[ADD] open_academy: Add Session report view T#59081

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -23,6 +23,7 @@
         "views/session_views.xml",
         "views/res_partner_views.xml",
         "wizards/add_attendee_sessions_views.xml",
+        "report/session_report.xml",
     ],
 
     "demo": [

--- a/open_academy/i18n/es.po
+++ b/open_academy/i18n/es.po
@@ -7,13 +7,23 @@ msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-08-22 16:15+0000\n"
-"PO-Revision-Date: 2022-08-22 16:15+0000\n"
+"PO-Revision-Date: 2022-09-06 14:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: open_academy
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
+msgid "<strong>End Date:</strong>"
+msgstr "<strong>Fecha de fin:</strong>"
+
+#. module: open_academy
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
+msgid "<strong>Start Date:</strong>"
+msgstr "<strong>Fecha de inicio:</strong>"
 
 #. module: open_academy
 #: model:ir.model.fields,field_description:open_academy.field_session__active
@@ -37,6 +47,7 @@ msgstr "Asistente"
 
 #. module: open_academy
 #: model:ir.model.fields,field_description:open_academy.field_session__attendee_ids
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
 #: model_terms:ir.ui.view,arch_db:open_academy.session_view_form
 msgid "Attendees"
 msgstr "Asistentes"
@@ -126,6 +137,21 @@ msgid "Duration:"
 msgstr "Duración:"
 
 #. module: open_academy
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
+msgid "Email"
+msgstr "Correo electrónico"
+
+#. module: open_academy
+#: model:ir.model.fields,field_description:open_academy.field_session__end_date
+msgid "End Date"
+msgstr "Fecha de fin"
+
+#. module: open_academy
+#: model_terms:ir.ui.view,arch_db:open_academy.session_view_kanban
+msgid "End Date:"
+msgstr "Fecha de fin:"
+
+#. module: open_academy
 #: model_terms:ir.ui.view,arch_db:open_academy.course_view_search
 msgid "Group By"
 msgstr "Agrupar Por"
@@ -197,6 +223,7 @@ msgstr "Mis Cursos"
 #. module: open_academy
 #: model:ir.model.fields,field_description:open_academy.field_course__name
 #: model:ir.model.fields,field_description:open_academy.field_session__name
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
 msgid "Name"
 msgstr "Nombre"
 
@@ -238,6 +265,11 @@ msgid "OpenAcademy / Manager"
 msgstr "OpenAcademy / Administrador"
 
 #. module: open_academy
+#: model_terms:ir.ui.view,arch_db:open_academy.session_report
+msgid "Phone"
+msgstr "Teléfono"
+
+#. module: open_academy
 #: model:ir.model.fields,field_description:open_academy.field_course__responsible_user_id
 #: model_terms:ir.ui.view,arch_db:open_academy.course_view_search
 msgid "Responsible User"
@@ -254,6 +286,11 @@ msgstr "Guardar"
 #: model:ir.model.fields,field_description:open_academy.field_res_users__session_ids
 msgid "Session"
 msgstr "Sesión"
+
+#. module: open_academy
+#: model:ir.actions.report,name:open_academy.report_session
+msgid "Session Report"
+msgstr "Reporte de Sesión"
 
 #. module: open_academy
 #: model:ir.actions.act_window,name:open_academy.session_action

--- a/open_academy/report/session_report.xml
+++ b/open_academy/report/session_report.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="report_session" model="ir.actions.report">
+        <field name="name">Session Report</field>
+        <field name="model">session</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">open_academy.session_report</field>
+        <field name="report_file">open_academy.session_report</field>
+        <field name="binding_model_id" ref="model_session"/>
+        <field name="binding_type">report</field>
+    </record>
+
+    <template id="session_report">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="session">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <h2 class="text-center">
+                            <span t-field="session.name"/>
+                        </h2>
+                    </div>
+                    <div class="text-center mt-4 mb-4">
+                        <strong>Start Date:</strong>
+                        <span t-field="session.start_date" class="mr-5"/>
+                        <strong>End Date:</strong>
+                        <span t-field="session.end_date"/>
+                    </div>
+                    <div class="text-center">
+                        <h3>Attendees</h3>
+                    </div>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Phone</th>
+                                <th>Email</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-foreach="session.mapped('attendee_ids')" t-as="attendee">
+                                <td>
+                                    <span t-field="attendee.name"/>
+                                </td>
+                                <td>
+                                    <span t-field="attendee.phone"/>
+                                </td>
+                                <td>
+                                    <span t-field="attendee.email"/>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/open_academy/views/session_views.xml
+++ b/open_academy/views/session_views.xml
@@ -17,6 +17,7 @@
                 <field name="course_id"/>
                 <field name="instructor_id"/>
                 <field name="start_date"/>
+                <field name="end_date"/>
                 <field name="lasting_days"/>
                 <field name="duration"/>
                 <field name="number_of_seats"/>
@@ -64,6 +65,7 @@
                 <field name="course_id"/>
                 <field name="instructor_id"/>
                 <field name="start_date"/>
+                <field name="end_date"/>
                 <field name="duration"/>
                 <field name="number_of_seats"/>
                 <field name="taken_seats" widget="progressbar"/>
@@ -90,6 +92,7 @@
                 <field name="name"/>
                 <field name="instructor_id"/>
                 <field name="start_date"/>
+                <field name="end_date"/>
                 <field name="duration"/>
                 <templates>
                     <t t-name="kanban-box">
@@ -106,6 +109,9 @@
                                     </li>
                                     <li>
                                         Start Date: <field name="start_date"/>
+                                    </li>
+                                    <li>
+                                        End Date: <field name="end_date"/>
                                     </li>
                                     <li>
                                         Duration: <field name="duration"/>


### PR DESCRIPTION
- Add report view for session model to display session name, start and end date, and the list of attendees.
![menu report](https://user-images.githubusercontent.com/108701886/188513107-97cbceea-eaba-4b0a-a896-cbe49bd6ac4f.png)

- Update es.po translation file to include strings from report functionality.

Test Session Report:
[Test session.pdf](https://github.com/JesusValdez96/open_academy/files/9492005/Test.session.pdf)

Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#printed-reports