### PR TITLE
[ADD] open_academy: Add session dashboard T#59081

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -13,6 +13,7 @@
 
     "depends": [
         "base",
+        "board",
     ],
 
     "data": [
@@ -20,6 +21,7 @@
         "security/ir_rule.xml",
         "security/ir.model.access.csv",
         "views/course_views.xml",
+        "views/session_dashboard.xml",
         "views/session_views.xml",
         "views/res_partner_views.xml",
         "wizards/add_attendee_sessions_views.xml",

--- a/open_academy/views/session_dashboard.xml
+++ b/open_academy/views/session_dashboard.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="session_graph_action" model="ir.actions.act_window">
+        <field name="name">Sessions Graph</field>
+        <field name="res_model">session</field>
+        <field name="view_mode">graph</field>
+    </record>
+
+    <record id="session_calendar_action" model="ir.actions.act_window">
+        <field name="name">Sessions Calendar</field>
+        <field name="res_model">session</field>
+        <field name="view_mode">calendar</field>
+    </record>
+
+    <record id="course_tree_action" model="ir.actions.act_window">
+        <field name="name">Courses</field>
+        <field name="res_model">course</field>
+        <field name="view_mode">tree</field>
+    </record>
+
+    <record id="session_view_dashboard" model="ir.ui.view">
+        <field name="name">session.view.dashboard</field>
+        <field name="model">board.board</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form>
+                <board style="1-2">
+                    <column>
+                        <action string="Session Graph" name="%(session_graph_action)d"/>
+                        <action string="Courses" name="%(course_tree_action)d"/>
+                    </column>
+                    <column>
+                        <action string="Session Calendar" name="%(session_calendar_action)d"/>
+                    </column>
+                </board>
+            </form>
+        </field>
+    </record>
+
+    <record id="session_dashboard_action" model="ir.actions.act_window">
+        <field name="name">Session Dashboard</field>
+        <field name="res_model">board.board</field>
+        <field name="view_mode">form</field>
+        <field name="usage">menu</field>
+        <field name="view_id" ref="session_view_dashboard"/>
+    </record>
+
+    <menuitem id="session_dashboard_menu" name="Session dashboard" sequence="1" action="session_dashboard_action" parent="session_menu" />
+</odoo>


### PR DESCRIPTION
- Add session dashboard menuitem in the session menu to access to the session dashboard view
that display the graph and calendar views of session model and the tree view of course model.

![dashboard](https://user-images.githubusercontent.com/108701886/189035486-e780ff37-699b-45c6-bd44-c5091bcc5797.png)

Link to exercise: https://www.odoo.com/documentation/15.0/developer/howtos/backend.html#dashboards